### PR TITLE
css/rule: add vendor prefixed at-rules

### DIFF
--- a/css/rule.go
+++ b/css/rule.go
@@ -20,7 +20,7 @@ const (
 
 // At Rules than have Rules inside their block instead of Declarations
 var atRulesWithRulesBlock = []string{
-	"@document", "@font-feature-values", "@keyframes", "@media", "@supports",
+	"@document", "@font-feature-values", "@keyframes", "@media", "@supports", "@-webkit-keyframes", "@-moz-keyframes", "@-o-keyframes",
 }
 
 // Selector represents a parsed CSS selector.


### PR DESCRIPTION
#### Details

This changes adds missing vendor at-rules vendor prefixes:
- `@-webkit-keyframes`
- `@-moz-keyframes`
- `@-o-keyframes`

Which fixes the following parsing error:
`failed to parse a source unit file: Unexpected } character: CHAR (line: x, column: t): "}"`
