### PR TITLE
malformed syntax improvement

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -286,9 +286,8 @@ func (parser *Parser) parseQualifiedRule() (*css.Rule, error) {
 			// finished
 			break
 		} else if parser.tokenChar(";") {
-			parser.shiftToken()
-			// finished
-			break
+			errMsg := fmt.Sprintf("Unexpected ; character: %s", parser.nextToken().String())
+			return result, errors.New(errMsg)
 		} else {
 			// parse prelude
 			prelude, err, tokens := parser.parsePrelude()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -861,22 +861,8 @@ func TestComments(t *testing.T) {
 
 func TestInfiniteLoop(t *testing.T) {
 	input := "{;}"
-
-	expectedRule := &css.Rule{
-		Kind:    css.QualifiedRule,
-		Prelude: "",
-		Selectors: []*css.Selector{
-			{
-				Value:  "",
-				Line:   0,
-				Column: 0,
-			},
-		},
-		Declarations: []*css.Declaration{},
+	_, err := Parse(input)
+	if err == nil {
+		t.Fatal("Expected an error got nil")
 	}
-
-	stylesheet := MustParse(t, input, 1)
-	rule := stylesheet.Rules[0]
-
-	MustEqualRule(t, rule, expectedRule)
 }


### PR DESCRIPTION
#### Description
- Considers the following case as malformed CSS syntax and returns an error:

`main.css`

```
{;}
```

Expected:
Syntax error.

Actual:
Considers it as valid CSS syntax and emits a CSS rule.
