### PR TITLE
fix formatting of empty CSS Rules

### DIFF
--- a/css/rule.go
+++ b/css/rule.go
@@ -213,7 +213,12 @@ func (rule *Rule) str(diff bool) string {
 	}
 
 	if (len(rule.Declarations) == 0) && (len(rule.Rules) == 0) {
-		result += ";"
+		if rule.Kind == QualifiedRule {
+			result += " {}"
+		} else {
+			// AtRule
+			result += ";"
+		}
 	} else {
 		result += " {\n"
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -81,6 +81,33 @@ p > a {
 	MustEqualCSS(t, stylesheet.String(), expectedOutput)
 }
 
+func TestQualifiedRuleWithoutDeclarations(t *testing.T) {
+	input := `.foo {
+}`
+
+	expectedRule := &css.Rule{
+		Kind:    css.QualifiedRule,
+		Prelude: ".foo",
+		Selectors: []*css.Selector{
+			{
+				Value:  ".foo",
+				Line:   1,
+				Column: 1,
+			},
+		},
+		Declarations: []*css.Declaration{},
+	}
+
+	expectedOutput := `.foo {}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
 func TestQualifiedRuleImportant(t *testing.T) {
 	input := `/* This is a comment */
 p > a {


### PR DESCRIPTION
Empty CSS rules break the formatted output.

Example:

`.foo {}`

becomes:

`.foo;`

instead of:

`.foo {}`